### PR TITLE
Pinned Action Versions in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: lint effx configuration files
-        uses: effxhq/effx-lint-action@master
+        uses: effxhq/effx-lint-action@v1
         with:
           directory: ${GITHUB_WORKSPACE}
 ```


### PR DESCRIPTION
## What
Recommend users to pin `effx-lint-action` to `v1`